### PR TITLE
fix: add callstack module to Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -255,6 +255,7 @@ COPY go.mod go.sum ./
 COPY go-ethereum/go.mod go-ethereum/go.sum go-ethereum/
 COPY fastcache/go.mod fastcache/go.sum fastcache/
 COPY bold/go.mod bold/go.sum bold/
+COPY callstack/go.mod callstack/go.sum callstack/
 RUN go mod download
 COPY . ./
 COPY --from=contracts-builder workspace/contracts/build/ contracts/build/


### PR DESCRIPTION
Fixes [#95](https://github.com/NethermindEth/nethermind-arbitrum/issues/95)