### PR TITLE
fix(ci): Docker multi-arch manifest creation for parallel native builds

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -19,14 +19,17 @@ jobs:
         include:
           - platform: linux/arm64
             runner: ubuntu-arm64-8-core
+            arch_suffix: -arm64
           - platform: linux/amd64
             runner: ubuntu-latest
+            arch_suffix: -amd64
     uses: NethermindEth/github-workflows/.github/workflows/docker-build-push-jfrog.yaml@v1.9.0
     with:
       group_name: core
       runner: ${{ matrix.runner }}
       image_name: 'arbitrum-nitro'
       platforms: ${{ matrix.platform }}
+      additional_tags: nethermind${{ matrix.arch_suffix }}
       pre_build_script: |
         sudo rm -rf /usr/share/dotnet
         sudo rm -rf /opt/ghc

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -23,7 +23,7 @@ jobs:
           - platform: linux/amd64
             runner: ubuntu-latest
             arch_suffix: -amd64
-    uses: NethermindEth/github-workflows/.github/workflows/docker-build-push-jfrog.yaml@v1.9.0
+    uses: NethermindEth/github-workflows/.github/workflows/docker-build-push-jfrog.yaml@v1.9.2
     with:
       group_name: core
       runner: ${{ matrix.runner }}
@@ -43,3 +43,38 @@ jobs:
         sudo apt-get clean
         docker system prune -af --volumes
         df -h
+
+  create-manifest:
+    name: Create multi-arch manifest
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install JFrog CLI
+        id: jfrog
+        uses: jfrog/setup-jfrog-cli@v4
+        env:
+          JF_URL: https://nethermind.jfrog.io
+        with:
+          oidc-provider-name: github-nethermindeth
+
+      - name: Login to Registry with OIDC
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: nethermind.jfrog.io
+          username: ${{ steps.jfrog.outputs.oidc-user }}
+          password: ${{ steps.jfrog.outputs.oidc-token }}
+
+      - name: Create and push multi-arch manifest
+        run: |
+          IMAGE_BASE="nethermind.jfrog.io/core-oci-local-dev/arbitrum-nitro"
+          TAG="nethermind"
+          
+          # Create manifest list
+          docker buildx imagetools create -t "${IMAGE_BASE}:${TAG}" \
+            "${IMAGE_BASE}:${TAG}-amd64" \
+            "${IMAGE_BASE}:${TAG}-arm64"
+          
+          echo "✅ Multi-arch manifest created: ${IMAGE_BASE}:${TAG}"
+          
+          # Verify manifest
+          docker buildx imagetools inspect "${IMAGE_BASE}:${TAG}"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -76,12 +76,31 @@ jobs:
           echo "AMD64 Digest: ${AMD64_DIGEST}"
           echo "ARM64 Digest: ${ARM64_DIGEST}"
           
-          # Create manifest list using specific digests (excludes attestations)
-          docker buildx imagetools create -t "${IMAGE_BASE}:${TAG}" \
-            "${IMAGE_BASE}@${AMD64_DIGEST}" \
-            "${IMAGE_BASE}@${ARM64_DIGEST}"
+          # Create all the tags that should be multi-arch
+          # Extract branch name for branch-based tag
+          BRANCH_NAME="${GITHUB_REF#refs/heads/}"
+          BRANCH_TAG="${BRANCH_NAME//\//-}"  # Replace / with -
           
-          echo "✅ Multi-arch manifest created: ${IMAGE_BASE}:${TAG}"
+          TAGS_TO_CREATE=(
+            "${TAG}"
+            "${BRANCH_TAG}"
+            "latest"
+            "$(date +%Y%m%d)"
+            "$(date +%Y%m%d)-${GITHUB_SHA:0:7}"
+            "sha-${GITHUB_SHA:0:7}"
+            "${GITHUB_SHA}"
+            "${GITHUB_SHA:0:7}"
+          )
           
-          # Verify manifest
+          # Create manifest for each tag using specific digests (excludes attestations)
+          for TAG_NAME in "${TAGS_TO_CREATE[@]}"; do
+            echo "Creating multi-arch manifest for: ${IMAGE_BASE}:${TAG_NAME}"
+            docker buildx imagetools create -t "${IMAGE_BASE}:${TAG_NAME}" \
+              "${IMAGE_BASE}@${AMD64_DIGEST}" \
+              "${IMAGE_BASE}@${ARM64_DIGEST}"
+          done
+          
+          echo "✅ Multi-arch manifests created for all tags"
+          
+          # Verify main tag manifest
           docker buildx imagetools inspect "${IMAGE_BASE}:${TAG}"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -69,10 +69,17 @@ jobs:
           IMAGE_BASE="nethermind.jfrog.io/core-oci-local-dev/arbitrum-nitro"
           TAG="nethermind"
           
-          # Create manifest list
+          # Pull architecture-specific digests (excluding attestations)
+          AMD64_DIGEST=$(docker buildx imagetools inspect "${IMAGE_BASE}:${TAG}-amd64" --raw | jq -r '.manifests[] | select(.platform.architecture == "amd64") | .digest')
+          ARM64_DIGEST=$(docker buildx imagetools inspect "${IMAGE_BASE}:${TAG}-arm64" --raw | jq -r '.manifests[] | select(.platform.architecture == "arm64") | .digest')
+          
+          echo "AMD64 Digest: ${AMD64_DIGEST}"
+          echo "ARM64 Digest: ${ARM64_DIGEST}"
+          
+          # Create manifest list using specific digests (excludes attestations)
           docker buildx imagetools create -t "${IMAGE_BASE}:${TAG}" \
-            "${IMAGE_BASE}:${TAG}-amd64" \
-            "${IMAGE_BASE}:${TAG}-arm64"
+            "${IMAGE_BASE}@${AMD64_DIGEST}" \
+            "${IMAGE_BASE}@${ARM64_DIGEST}"
           
           echo "✅ Multi-arch manifest created: ${IMAGE_BASE}:${TAG}"
           


### PR DESCRIPTION
## Problem:

- Parallel Docker builds on native runners (amd64 + arm64) were creating corrupted manifests with "unknown" platform entries
- Docker pull failed with "no matching manifest for linux/arm64/v8" error
- Root cause: Build attestations and simultaneous pushes to the same tag created invalid manifest lists

## Solution:

- Added architecture suffixes (-amd64, -arm64) to parallel build jobs to prevent tag conflicts
- Implemented Create-Manifest job that:
- Extracts clean image digests (excluding attestations) from architecture-specific tags
- Creates proper multi-arch manifests using digest-based references
Recreates all automatic tags (branch, date, commit, latest) as valid multi-arch manifests